### PR TITLE
Fixed mismatch of 3rd party Pro controllers

### DIFF
--- a/src/hid-nintendo.c
+++ b/src/hid-nintendo.c
@@ -1513,6 +1513,15 @@ static int joycon_input_create(struct joycon_ctlr *ctlr)
 	int ret;
 	int i;
 
+        /*Some 3rd party Switch Pro controllers report Product ID 0x2006
+          instead of 0x2009.
+          Check reported controller type and force Product ID to PROCON.
+        */
+        if(ctlr->ctlr_type == JOYCON_CTLR_TYPE_PRO &&
+           ctlr->hdev->product != USB_DEVICE_ID_NINTENDO_PROCON){
+           ctlr->hdev->product = USB_DEVICE_ID_NINTENDO_PROCON;
+        }
+
 	hdev = ctlr->hdev;
 
 	switch (hdev->product) {


### PR DESCRIPTION
Some 3rd party Pro controllers report product ID 0x2006 instead of 0x2009. This causes them to get misidentified as "Left Joycon".

While most functions work OK, both left trigger buttons (L, ZL) are disabled. 
I proposed that when the device reports it is a Pro controller and the reported Device ID is not correct, that it is manually corrected to 0x2009. 

The misbehaving controllers works perfectly with a Switch console.