### PR TITLE
port hid-nintendo rumble reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ git clone https://github.com/nicman23/dkms-hid-nintendo
 cd dkms-hid-nintendo
 
 sudo dkms add .
-sudo dkms build nintendo -v 3.1
-sudo dkms install nintendo -v 3.1
+sudo dkms build nintendo -v 3.2
+sudo dkms install nintendo -v 3.2
 ```
 
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="nintendo"
-PACKAGE_VERSION=3.1
+PACKAGE_VERSION=3.2
 MAKE="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/src modules"
 CLEAN="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/src clean"
 BUILT_MODULE_NAME[0]="hid-nintendo"


### PR DESCRIPTION
Introduces max rate for sending subcommands and rumble data.
Sends rumble data after receiving an input report.
Improve the logic for not sending zero-amp rumble data packets in order
to avoid situations where rumble gets stuck on until timing out.

Signed-off-by: Daniel J. Ogorchock <djogorchock@gmail.com>